### PR TITLE
Implement form persistence and dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
     </div>
 
     <section id="dashboard" class="hidden"></section>
-
+    <script src="https://cdn.jsdelivr.net/npm/d3@7"></script>
     <script type="module" src="./src/main.js"></script>
   </body>
 </html>

--- a/src/charts/bars.js
+++ b/src/charts/bars.js
@@ -1,0 +1,24 @@
+export function drawBars(el, dataset) {
+  const w = el.clientWidth, h = 220, margin = 40;
+  const svg = d3.select(el).html('').append('svg')
+      .attr('width', w).attr('height', h);
+
+  const x = d3.scaleLinear()
+      .domain([0, d3.max(dataset, d => d.value)])
+      .range([margin, w - margin]);
+
+  const y = d3.scaleBand()
+      .domain(dataset.map(d => d.label))
+      .range([margin, h - margin])
+      .padding(0.1);
+
+  svg.append('g')
+     .selectAll('rect')
+     .data(dataset)
+     .join('rect')
+       .attr('x', margin)
+       .attr('y', d => y(d.label))
+       .attr('height', y.bandwidth())
+       .attr('width', d => x(d.value) - margin)
+       .attr('fill', '#00cfe8');
+}

--- a/src/charts/donuts.js
+++ b/src/charts/donuts.js
@@ -1,0 +1,15 @@
+export function drawDonut(el, value) {
+  const w = 220, h = 220, r = 80;
+  const svg = d3.select(el).html('').append('svg')
+      .attr('width', w).attr('height', h)
+    .append('g')
+      .attr('transform', `translate(${w/2},${h/2})`);
+
+  const arc = d3.arc().innerRadius(r*0.6).outerRadius(r);
+  svg.append('path')
+     .attr('d', arc({ startAngle: 0, endAngle: 2*Math.PI*value }))
+     .attr('fill', '#00cfe8');
+  svg.append('path')
+     .attr('d', arc({ startAngle: 2*Math.PI*value, endAngle: 2*Math.PI }))
+     .attr('fill', '#222');
+}

--- a/src/charts/map.js
+++ b/src/charts/map.js
@@ -1,0 +1,35 @@
+export async function drawChoropleth(el, geojson, metrics) {
+  // el = contenedor (div)
+  const w = el.clientWidth, h = 400;
+  const svg = d3.select(el).html('').append('svg')
+                .attr('width', w).attr('height', h);
+
+  const projection = d3.geoMercator()
+        .center([13, 52])        // aproximación a Europa central
+        .scale(450)
+        .translate([w/2, h/2]);
+
+  const path = d3.geoPath().projection(projection);
+
+  // escala color verde→rojo
+  const color = d3.scaleLinear()
+        .domain([0, 1])
+        .range(['#0f0', '#f00']);
+
+  svg.append('g')
+     .selectAll('path')
+     .data(geojson.features)
+     .join('path')
+       .attr('d', path)
+       .attr('fill', d => {
+         const cc = d.properties.ISO_A3;          // código país iso3
+         const v  = metrics[cc];                  // 0-1
+         return v == null ? '#ccc' : color(v);
+       })
+       .attr('stroke', '#000')
+       .on('click', (e,d) => {
+          // al pinchar país → recalcular gráficos
+          const cc = d.properties.ISO_A3;
+          window.renderChartsForCountry(cc);      // función global
+       });
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,217 +1,257 @@
-// src/main.js
+/*  src/main.js   –  Vanilla JS + D3 v7  */
+/*  ------------  PANTALLAS -------------
+      Intro  →  Formulario  →  Dashboard
+---------------------------------------- */
 
-import { csv } from 'd3';
+/// CDN de D3 (asegúrate de tenerla en index.html antes de este script)
+/// <script src="https://cdn.jsdelivr.net/npm/d3@7"></script>
 
-// DOM elements
-const startButton = document.getElementById('start-button');
-const introDiv = document.getElementById('intro');
-const formContainer = document.getElementById('form-container');
-const dataForm = document.getElementById('data-form');
-const dashboard = document.getElementById('dashboard');
+///// 1.  SELECTORES y CONSTANTES
+const btnStart  = document.getElementById('start-button');
+const intro     = document.getElementById('intro');
+const formWrap  = document.getElementById('form-container');
+const form      = document.getElementById('data-form');
+const dash      = document.getElementById('dashboard');
 
-// Variables whose options come from the CSV dataset
-const CSV_VARIABLES = [
-  'A9',
-  'A12',
-  'G1',
-  'G2',
-  'G19',
-  'RESPONDENT_SO',
-  'RESPONDENT_GIE'
-];
+const CSV_VARIABLES = ['A9','A12','G1','G2','G19','RESPONDENT_SO','RESPONDENT_GIE'];
+const LS_KEY = 'surveyAnswers';
 
-/**
- * Generate age ranges for the <select id="age"> element.
- */
-function buildAgeOptions() {
-  const ageSelect = document.getElementById('age');
-  if (!ageSelect) return;
-  const frag = document.createDocumentFragment();
-  const placeholder = document.createElement('option');
-  placeholder.value = '';
-  placeholder.disabled = true;
-  placeholder.selected = true;
-  placeholder.textContent = 'Selecciona...';
-  frag.appendChild(placeholder);
+let GEO=null, DATA=null;           // se llenan en init()
 
-  for (let start = 15; start <= 85; start += 5) {
-    const opt = document.createElement('option');
-    const label = `${start}-${start + 4}`;
-    opt.value = label;
-    opt.textContent = label;
-    frag.appendChild(opt);
-  }
-  const plus = document.createElement('option');
-  plus.value = '90+';
-  plus.textContent = '90 o más';
-  frag.appendChild(plus);
+///// 2.  PERSISTENCIA
+const saveAns = o   => localStorage.setItem(LS_KEY,JSON.stringify(o));
+const loadAns = ()  => JSON.parse(localStorage.getItem(LS_KEY)||'null');
 
-  ageSelect.appendChild(frag);
+///// 3.  FORMULARIO DINÁMICO
+function buildAgeRanges(){
+  const sel=document.getElementById('age');
+  sel.innerHTML='<option value="" disabled selected>Selecciona...</option>';
+  for(let a=15;a<=85;a+=5)
+    sel.insertAdjacentHTML('beforeend',`<option>${a}-${a+4}</option>`);
+  sel.insertAdjacentHTML('beforeend','<option value="90+">90 o más</option>');
 }
 
-/**
- * Populate the remaining <select> elements with unique values from the CSV.
- */
-async function populateSelects() {
-  const data = await csv('./data/selected_variables.csv');
-
-  CSV_VARIABLES.forEach((varName) => {
-    const select = document.getElementById(varName);
-    if (!select) return;
-
-    const values = Array.from(
-      new Set(
-        data
-          .map((d) => d[varName])
-          .filter((v) => v !== undefined && v !== null && v !== '')
-      )
-    ).sort();
-
-    const frag = document.createDocumentFragment();
-    const placeholder = document.createElement('option');
-    placeholder.value = '';
-    placeholder.disabled = true;
-    placeholder.selected = true;
-    placeholder.textContent = 'Selecciona...';
-    frag.appendChild(placeholder);
-
-    values.forEach((v) => {
-      const opt = document.createElement('option');
-      opt.value = v;
-      opt.textContent = v;
-      frag.appendChild(opt);
-    });
-
-    select.appendChild(frag);
+function fillSelects(){
+  CSV_VARIABLES.forEach(v=>{
+    const sel=document.getElementById(v);
+    if(!sel) return;
+    const vals=[...new Set(DATA.map(d=>d[v]).filter(Boolean))].sort();
+    sel.innerHTML='<option value="" disabled selected>Selecciona...</option>';
+    vals.forEach(val=>sel.insertAdjacentHTML('beforeend',`<option>${val}</option>`));
   });
 }
 
-/**
- * Gather all answers from the form.
- */
-function getAnswersFromForm() {
-  const formData = new FormData(dataForm);
-  const answers = {};
-  for (const [key, value] of formData.entries()) {
-    answers[key] = value;
-  }
-  return answers;
+function preloadForm(o){
+  Object.entries(o||{}).forEach(([k,v])=>{
+    const el=form.elements[k];
+    if(el) el.value=v;
+  });
 }
 
-/**
- * Preload form fields with given answers.
- */
-function preloadForm(answers) {
-  Object.entries(answers).forEach(([key, value]) => {
-    const field = dataForm.elements[key];
-    if (field) {
-      field.value = value;
+///// 4.  FILTRADO y MÉTRICAS
+const isOne = v => v==='Selected' || v==='Yes';
+
+function filteredRows(f){
+  return DATA.filter(r=>{
+    if(f.age){
+      const [a,b]=f.age.split('-');
+      const n=+r.A1;                         // columna de edad
+      if(b ? !(n>=+a&&n<=+b) : n<90) return false;
     }
-  });
-}
-
-/** Save answers to localStorage */
-function saveAnswers(answers) {
-  localStorage.setItem('surveyAnswers', JSON.stringify(answers));
-}
-
-/** Load answers from localStorage */
-function loadAnswers() {
-  const raw = localStorage.getItem('surveyAnswers');
-  return raw ? JSON.parse(raw) : null;
-}
-
-/**
- * Render dashboard and tabbed navigation.
- */
-function renderDashboard(answers) {
-  dashboard.innerHTML = '';
-
-  const tabs = document.createElement('div');
-  tabs.id = 'tabs';
-  ['mental', 'apertura', 'violencia', 'discriminacion'].forEach((t) => {
-    const btn = document.createElement('button');
-    btn.dataset.tab = t;
-    btn.textContent =
-      t === 'mental'
-        ? 'Salud mental'
-        : t === 'apertura'
-        ? 'Apertura'
-        : t === 'violencia'
-        ? 'Violencia'
-        : 'Discriminación';
-    tabs.appendChild(btn);
-  });
-  dashboard.appendChild(tabs);
-
-  const container = document.createElement('div');
-  container.id = 'viz-container';
-  dashboard.appendChild(container);
-
-  const back = document.createElement('button');
-  back.id = 'back-btn';
-  back.textContent = 'Volver al cuestionario';
-  dashboard.appendChild(back);
-
-  const filters = { ...answers };
-
-  tabs.querySelectorAll('button').forEach((btn) => {
-    btn.addEventListener('click', () => {
-      tabs.querySelectorAll('button').forEach((b) => b.classList.remove('active'));
-      btn.classList.add('active');
-      renderTab(btn.dataset.tab, filters);
+    return Object.entries(f).every(([k,v])=>{
+      if(k==='age'||!v) return true;
+      return r[k]===v;
     });
   });
+}
 
-  back.addEventListener('click', () => {
-    dashboard.classList.add('hidden');
-    formContainer.classList.remove('hidden');
-    introDiv.classList.remove('hidden');
+function pct(variable,f){                   // 0-1
+  const rows=filteredRows(f);
+  const ones=rows.filter(r=>isOne(r[variable])).length;
+  return rows.length? ones/rows.length : 0;
+}
+
+function choroplethByCountry(tab,f){
+  const VARS={
+    mental:['C1_E','C1_F','D1_2_a','D1_2_b','D1_2_c','D1_2_d','D1_2_e'],
+    apertura:['B5_A','B5_B','B5_C','B5_D'],
+    violencia:['E1','F1']
+  }[tab]||[];
+  const map={};
+  filteredRows(f).forEach(r=>{
+    const ok=VARS.every(v=>isOne(r[v]))?1:0;
+    (map[r.A9]??=[]).push(ok);              // A9 = país residencia (nombre textual)
   });
-
-  renderTab('mental', filters);
+  Object.keys(map).forEach(k=>map[k]=d3.mean(map[k]));
+  return map;                               // { "Spain":0.42, ... }
 }
 
-/**
- * Render a specific tab with placeholder images.
- */
-function renderTab(tabName, filters) {
-  const container = document.getElementById('viz-container');
-  if (!container) return;
-  container.innerHTML = '';
+///// 5.  D3 – DRAW
+function drawMap(target, geo, metrics){
+  const w = target.clientWidth || 900;
+  const h = 440;                                // un pelín más alto
+  const svg = d3.select(target).html('')
+                .append('svg')
+                .attr('viewBox',[0,0,w,h]);
 
-  const mapImg = document.createElement('img');
-  mapImg.src = `img/mapa_${tabName}.png`;
-  container.appendChild(mapImg);
+  /* --- proyección --- */
+  const proj = d3.geoMercator().fitSize([w,h-40], geo);
+  const path = d3.geoPath().projection(proj);
 
-  for (let i = 1; i <= 3; i++) {
-    const img = document.createElement('img');
-    img.src = `img/${tabName}_chart${i}.png`;
-    container.appendChild(img);
-  }
+  /* --- dominio real de valores --- */
+  const values = Object.values(metrics).filter(v=>v!=null);
+  const min = d3.min(values), max = d3.max(values);
+  const color = d3.scaleLinear()
+                  .domain([min, max])           // min → green  | max → red
+                  .range(['#0f0', '#f00']);
+
+  /* --- mapa --- */
+  svg.append('g')
+     .selectAll('path')
+     .data(geo.features)
+     .join('path')
+       .attr('d', path)
+       .attr('fill',d=>{
+          const v = metrics[d.properties.NAME];
+          return v==null ? '#555' : color(v);
+       })
+       .attr('stroke','#000')
+       .append('title')
+       .text(d=>{
+         const v = metrics[d.properties.NAME];
+         return `${d.properties.NAME}: ${v!=null ? d3.format('.0%')(v) : 'sin datos'}`;
+       });
+
+  /* --- leyenda --- */
+  const defs = svg.append('defs');
+  const grad = defs.append('linearGradient')
+                   .attr('id','grad')
+                   .attr('x1','0%').attr('x2','100%');
+  grad.append('stop').attr('offset','0%').attr('stop-color', color(min));
+  grad.append('stop').attr('offset','100%').attr('stop-color', color(max));
+
+  // barra
+  svg.append('rect')
+     .attr('id','map-legend')
+     .attr('x', (w-260)/2)
+     .attr('y', h-32)
+     .attr('width',260)
+     .attr('height',14)
+     .attr('fill','url(#grad)');
+
+  // etiquetas numéricas
+  svg.append('g')
+     .attr('id','legend-labels')
+     .selectAll('text')
+     .data([min,max])
+     .join('text')
+       .attr('x',(d,i)=> (w-260)/2 + (i?260:0))
+       .attr('y', h-6)
+       .attr('text-anchor', (d,i)=> i?'end':'start')
+       .text(d=> d3.format('.0%')(d));
 }
 
-// ----------------- Init -----------------
 
-buildAgeOptions();
-populateSelects().then(() => {
-  const stored = loadAnswers();
-  if (stored) {
-    preloadForm(stored);
-  }
-});
+function drawBars(target,data){
+  const w=360,h=260,m=40;
+  const svg=d3.select(target).html('').append('svg').attr('viewBox',[0,0,w,h]);
+  const x=d3.scaleLinear().domain([0,d3.max(data,d=>d.value)]).range([m,w-m]);
+  const y=d3.scaleBand().domain(data.map(d=>d.label)).range([m,h-m]).padding(0.1);
+  svg.append('g').selectAll('rect')
+     .data(data).join('rect')
+     .attr('x',m).attr('y',d=>y(d.label))
+     .attr('height',y.bandwidth()).attr('width',d=>x(d.value)-m)
+     .attr('fill','#00cfe8');
+}
 
-startButton.addEventListener('click', () => {
-  introDiv.style.display = 'none';
-  formContainer.classList.remove('hidden');
-});
+function drawDonut(target,val){
+  const w=220,h=220,r=80,svg=d3.select(target).html('')
+    .append('svg').attr('viewBox',[0,0,w,h])
+    .append('g').attr('transform',`translate(${w/2},${h/2})`);
+  const arc=d3.arc().innerRadius(r*0.6).outerRadius(r);
+  svg.append('path').attr('d',arc({startAngle:0,endAngle:2*Math.PI*val})).attr('fill','#00cfe8');
+  svg.append('path').attr('d',arc({startAngle:2*Math.PI*val,endAngle:2*Math.PI})).attr('fill','#222');
+  svg.append('text').attr('dy','.35em').attr('text-anchor','middle').attr('fill','#fff')
+     .text(d3.format('.0%')(val));
+}
 
-dataForm.addEventListener('submit', (e) => {
+///// 6.  DASHBOARD
+function renderTab(tab,f){
+  const vc=document.getElementById('viz-container'); vc.innerHTML='';
+  const mapDiv=document.createElement('div');mapDiv.className='map';vc.appendChild(mapDiv);
+  drawMap(mapDiv,GEO,choroplethByCountry(tab,f));
+
+  const charts=document.createElement('div');charts.className='charts';vc.appendChild(charts);
+
+  if(tab==='mental')
+    drawBars(charts.appendChild(document.createElement('div')),
+             ['C1_E','C1_F','D1_2_a','D1_2_b','D1_2_c','D1_2_d','D1_2_e']
+               .map(v=>({label:v,value:pct(v,f)})));
+
+  if(tab==='apertura')
+    drawDonut(charts.appendChild(document.createElement('div')), pct('H2',f));
+
+  if(tab==='violencia')
+    ['E1','E3','F1'].forEach(v=>drawDonut(charts.appendChild(document.createElement('div')),pct(v,f)));
+
+  if(tab==='discriminacion')
+    drawBars(charts.appendChild(document.createElement('div')),
+      ['B5_A','B5_B','B5_C','B5_D'].map(v=>({label:v,value:pct(v,f)})));
+}
+
+function showDashboard(filters){
+  dash.innerHTML='';
+  const tabs=document.createElement('div');tabs.id='tabs';
+  [['mental','Salud mental'],['apertura','Apertura'],['violencia','Violencia'],['discriminacion','Discriminación']]
+    .forEach(([id,txt])=>{
+      const b=document.createElement('button');b.textContent=txt;b.dataset.tab=id;
+      tabs.appendChild(b);
+    });
+  const backBtn=document.createElement('button');
+  backBtn.id='back-btn'; backBtn.textContent='Volver al cuestionario';
+
+  dash.append(tabs,Object.assign(document.createElement('div'),{id:'viz-container'}),backBtn);
+
+  tabs.onclick=e=>{
+    if(e.target.tagName!=='BUTTON')return;
+    tabs.querySelectorAll('button').forEach(b=>b.classList.toggle('active',b===e.target));
+    renderTab(e.target.dataset.tab,filters);
+  };
+  tabs.firstChild.classList.add('active');
+  renderTab('mental',filters);
+
+  backBtn.onclick=()=>{
+    dash.classList.add('hidden');
+    formWrap.classList.remove('hidden');     // ► solo mostramos formulario
+  };
+}
+
+///// 7.  INICIO
+(async function init(){
+  [GEO,DATA] = await Promise.all([
+    d3.json('/data/europe.geojson'),
+    d3.csv('/data/selected_variables.csv',d3.autoType)
+  ]);
+  buildAgeRanges();
+  fillSelects();
+  const stored=loadAns(); if(stored) preloadForm(stored);
+})();
+
+///// 8.  EVENTOS
+btnStart.onclick = ()=>{
+  intro.classList.add('hidden');
+  formWrap.classList.remove('hidden');
+};
+
+form.addEventListener('submit',e=>{
   e.preventDefault();
-  const answers = getAnswersFromForm();
-  saveAnswers(answers);
-  introDiv.classList.add('hidden');
-  formContainer.classList.add('hidden');
-  dashboard.classList.remove('hidden');
-  renderDashboard(answers);
+  if([...form.elements].some(el=>el.tagName==='SELECT' && !el.value))
+    return alert('Completa todas las preguntas');
+
+  const ans=Object.fromEntries(new FormData(form));
+  saveAns(ans);
+
+  formWrap.classList.add('hidden');
+  dash.classList.remove('hidden');
+  showDashboard(ans);
 });

--- a/src/style.css
+++ b/src/style.css
@@ -79,13 +79,16 @@ html, body {
 
 /* Estilo contenedor del formulario (aparece bajo #intro) */
 #form-container {
+  position: absolute;           /* ► centrado real, sin scroll */
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   max-width: 800px;
-  margin: 20px auto 40px auto;
-  background-color: #111; /* fondo oscuro sólido */
-  border: 1px solid #333;
-  border-radius: 5px;
-  padding: 20px;
-  box-sizing: border-box;
+  background:#111;
+  border:1px solid #333;
+  border-radius:5px;
+  padding:20px;
+  box-sizing:border-box;
 }
 
 /* ===== ESTILOS INTERNO DEL FORMULARIO ===== */
@@ -146,4 +149,40 @@ input[type="email"] {
 
 #data-form button[type="submit"]:hover {
   background-color: #0056b3;
+}
+
+
+/* ==== DASHBOARD ==== */
+#viz-container .map   { width: 100%; max-width: 900px; height: 420px; margin: 60px auto 40px; }
+#viz-container .charts{ display:flex;gap:2rem;justify-content:center;flex-wrap:wrap; }
+#viz-container .charts>div{ background:#b5ffff;padding:1rem; }
+
+/* Tabs */
+#tabs{display:flex;gap:4px;margin-left:8px;}
+#tabs button{border:none;padding:2px 6px;font-size:14px;cursor:pointer}
+#tabs button.active{background:#ffe46b;color:#000}
+#tabs button:not(.active){background:#00cfe8;color:#000}
+
+/* --- CENTRAR DASHBOARD --- */
+#dashboard{
+  position:absolute;
+  inset:0;                /* ocupa toda la pantalla */
+  overflow:auto;          /* scroll si el contenido crece */
+}
+
+/* Leyenda del mapa */
+#map-legend{
+  width:260px;
+  height:14px;
+  margin:10px auto 0;
+  display:block;
+  border:1px solid #333;
+}
+#legend-labels{
+  width:260px;
+  margin:4px auto 30px;
+  display:flex;
+  justify-content:space-between;
+  font-size:12px;
+  color:#fff;
 }


### PR DESCRIPTION
## Summary
- prefill age ranges and other select inputs
- save/reload answers in localStorage
- switch between form and dashboard
- render dashboard tabs with placeholder images

## Testing
- `npm run build` *(fails: vite not found)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68432a85ab44833383293e55276e7423